### PR TITLE
Fix link count desync

### DIFF
--- a/src/main/kotlin/io/github/cotrin8672/cel/CreateEnderLink.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/CreateEnderLink.kt
@@ -8,6 +8,8 @@ import io.github.cotrin8672.cel.content.block.tank.EnderTankBlockEntity
 import io.github.cotrin8672.cel.content.block.vault.EnderVaultBlockEntity
 import io.github.cotrin8672.cel.datagen.CelDatagen
 import io.github.cotrin8672.cel.network.SyncSharedStoragePacket
+import io.github.cotrin8672.cel.network.SyncFrequencyCountPacket
+import io.github.cotrin8672.cel.client.LinkCountClient
 import io.github.cotrin8672.cel.registry.*
 import io.github.cotrin8672.cel.util.SharedStorageHandler
 import net.createmod.catnip.lang.FontHelper
@@ -63,6 +65,15 @@ object CreateEnderLink {
             context.enqueueWork {
                 val level = context.player().level()
                 SharedStorageHandler.instance = SharedStorageHandler.load(packet.data, level.registryAccess())
+            }
+        }
+        registrar.playBidirectional(
+            SyncFrequencyCountPacket.TYPE,
+            SyncFrequencyCountPacket.STREAM_CODEC,
+        ) { packet, context ->
+            context.enqueueWork {
+                val level = context.player().level()
+                LinkCountClient.update(packet.data, level.registryAccess())
             }
         }
     }

--- a/src/main/kotlin/io/github/cotrin8672/cel/client/LinkCountClient.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/client/LinkCountClient.kt
@@ -1,0 +1,47 @@
+package io.github.cotrin8672.cel.client
+
+import io.github.cotrin8672.cel.content.block.tank.EnderTankBlockEntity
+import io.github.cotrin8672.cel.content.block.vault.EnderVaultBlockEntity
+import io.github.cotrin8672.cel.util.StorageFrequency
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.nbt.ListTag
+import net.minecraft.nbt.Tag
+import net.minecraft.core.HolderLookup
+import com.simibubi.create.foundation.blockEntity.SmartBlockEntity
+
+object LinkCountClient {
+    private val vaultCounts = mutableMapOf<StorageFrequency, Int>()
+    private val tankCounts = mutableMapOf<StorageFrequency, Int>()
+
+    fun update(tag: CompoundTag, registries: HolderLookup.Provider) {
+        vaultCounts.clear()
+        tankCounts.clear()
+        if (tag.contains("vault", Tag.TAG_LIST.toInt())) {
+            readList(tag.getList("vault", Tag.TAG_COMPOUND.toInt()), registries) { freq, count ->
+                vaultCounts[freq] = count
+            }
+        }
+        if (tag.contains("tank", Tag.TAG_LIST.toInt())) {
+            readList(tag.getList("tank", Tag.TAG_COMPOUND.toInt()), registries) { freq, count ->
+                tankCounts[freq] = count
+            }
+        }
+    }
+
+    fun getCount(be: SmartBlockEntity, frequency: StorageFrequency): Int {
+        return when (be) {
+            is EnderVaultBlockEntity -> vaultCounts[frequency] ?: 0
+            is EnderTankBlockEntity -> tankCounts[frequency] ?: 0
+            else -> 0
+        }
+    }
+
+    private fun readList(list: ListTag, registries: HolderLookup.Provider, accept: (StorageFrequency, Int) -> Unit) {
+        for (element in list) {
+            if (element !is CompoundTag) continue
+            val freq = StorageFrequency.parseOptional(registries, element.getCompound("StorageFrequency"))
+            val count = element.getInt("Count")
+            accept(freq, count)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/cotrin8672/cel/content/SharedStorageBehaviour.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/content/SharedStorageBehaviour.kt
@@ -8,6 +8,8 @@ import com.simibubi.create.foundation.blockEntity.SmartBlockEntity
 import com.simibubi.create.foundation.blockEntity.behaviour.*
 import com.simibubi.create.foundation.blockEntity.behaviour.ValueSettingsBehaviour.ValueSettings
 import com.simibubi.create.foundation.utility.CreateLang
+import LinkCountManager
+import ServerLevel
 import com.simibubi.create.infrastructure.config.AllConfigs
 import io.github.cotrin8672.cel.registry.CelDataComponents
 import io.github.cotrin8672.cel.registry.CelItems
@@ -109,9 +111,13 @@ open class SharedStorageBehaviour(
     }
 
     fun setStorageFrequency(storageFrequency: StorageFrequency) {
+        val old = this.storageFrequency
         this.storageFrequency = storageFrequency
         blockEntity.setChanged()
         blockEntity.sendData()
+        if (blockEntity.level is ServerLevel && old != storageFrequency) {
+            LinkCountManager.sync(blockEntity.level as ServerLevel)
+        }
     }
 
     open fun setFrequencyItem(face: Direction?, stack: ItemStack): Boolean {
@@ -197,14 +203,10 @@ open class SharedStorageBehaviour(
     fun addToGoggleTooltip(
         tooltip: MutableList<Component>,
         isPlayerSneaking: Boolean,
-        blockEntities: Set<SmartBlockEntity>,
     ) {
         val frequencyItem = getFrequency().stack
         val frequencyOwner = getFrequency().resolvableProfile
-
-        val count = blockEntities.count {
-            getFrequency() == it.getBehaviour(SharedStorageBehaviour.TYPE).getFrequency()
-        }
+        val count = io.github.cotrin8672.cel.client.LinkCountClient.getCount(blockEntity, getFrequency())
 
         CelLang.translate("gui.goggles.storage_stat").forGoggles(tooltip)
 

--- a/src/main/kotlin/io/github/cotrin8672/cel/content/block/tank/EnderTankBlockEntity.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/content/block/tank/EnderTankBlockEntity.kt
@@ -8,6 +8,7 @@ import io.github.cotrin8672.cel.content.SharedStorageBehaviour
 import io.github.cotrin8672.cel.content.storage.SharedFluidTank
 import io.github.cotrin8672.cel.registry.CelBlockEntityTypes
 import io.github.cotrin8672.cel.util.SharedStorageHandler
+import io.github.cotrin8672.cel.util.LinkCountManager
 import net.createmod.ponder.api.level.PonderLevel
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
@@ -39,12 +40,14 @@ class EnderTankBlockEntity(
         private val blockEntities: MutableSet<EnderTankBlockEntity> = Collections.newSetFromMap(WeakHashMap())
 
         fun getLoadingBlockEntities(): Set<EnderTankBlockEntity> = blockEntities.toSet()
-    }
+    } 
 
     init {
         val isAlreadyExists = blockEntities.map { it.blockPos }.contains(this.blockPos)
         if (!isAlreadyExists) blockEntities.add(this)
     }
+
+    private var firstTick = true
 
     private var luminosity = 0
     private var queuedSync = false
@@ -77,6 +80,11 @@ class EnderTankBlockEntity(
     override fun tick() {
         super.tick()
 
+        if (firstTick && level is ServerLevel) {
+            firstTick = false
+            LinkCountManager.sync(level as ServerLevel)
+        }
+
         if (syncCooldown > 0) {
             syncCooldown--
             if (syncCooldown == 0 && queuedSync) sendData()
@@ -92,7 +100,7 @@ class EnderTankBlockEntity(
         )
         tooltip.add(CommonComponents.EMPTY)
 
-        getBehaviour(SharedStorageBehaviour.TYPE).addToGoggleTooltip(tooltip, isPlayerSneaking, blockEntities)
+        getBehaviour(SharedStorageBehaviour.TYPE).addToGoggleTooltip(tooltip, isPlayerSneaking)
 
         return true
     }
@@ -100,16 +108,19 @@ class EnderTankBlockEntity(
     override fun destroy() {
         super.destroy()
         blockEntities.remove(this)
+        if (level is ServerLevel) LinkCountManager.sync(level as ServerLevel)
     }
 
     override fun remove() {
         super.remove()
         blockEntities.remove(this)
+        if (level is ServerLevel) LinkCountManager.sync(level as ServerLevel)
     }
 
     override fun onChunkUnloaded() {
         super.onChunkUnloaded()
         blockEntities.remove(this)
+        if (level is ServerLevel) LinkCountManager.sync(level as ServerLevel)
     }
 
     override fun sendData() {

--- a/src/main/kotlin/io/github/cotrin8672/cel/content/block/vault/EnderVaultBlockEntity.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/content/block/vault/EnderVaultBlockEntity.kt
@@ -7,6 +7,7 @@ import com.simibubi.create.foundation.blockEntity.behaviour.CenteredSideValueBox
 import io.github.cotrin8672.cel.content.SharedStorageBehaviour
 import io.github.cotrin8672.cel.registry.CelBlockEntityTypes
 import io.github.cotrin8672.cel.util.SharedStorageHandler
+import io.github.cotrin8672.cel.util.LinkCountManager
 import net.minecraft.core.BlockPos
 import net.minecraft.network.chat.Component
 import net.minecraft.server.level.ServerLevel
@@ -41,6 +42,8 @@ class EnderVaultBlockEntity(
         if (!isAlreadyExists) blockEntities.add(this)
     }
 
+    private var firstTick = true
+
     private fun getInventory(): IItemHandler? {
         val behaviour = getBehaviour(SharedStorageBehaviour.TYPE) ?: return null
         val nonNullLevel = level ?: return null
@@ -57,9 +60,17 @@ class EnderVaultBlockEntity(
         }))
     }
 
+    override fun tick() {
+        super.tick()
+        if (firstTick && level is ServerLevel) {
+            firstTick = false
+            LinkCountManager.sync(level as ServerLevel)
+        }
+    }
+
     override fun addToGoggleTooltip(tooltip: MutableList<Component>, isPlayerSneaking: Boolean): Boolean {
         super.addToGoggleTooltip(tooltip, isPlayerSneaking)
-        getBehaviour(SharedStorageBehaviour.TYPE).addToGoggleTooltip(tooltip, isPlayerSneaking, blockEntities)
+        getBehaviour(SharedStorageBehaviour.TYPE).addToGoggleTooltip(tooltip, isPlayerSneaking)
 
         return true
     }
@@ -67,15 +78,18 @@ class EnderVaultBlockEntity(
     override fun destroy() {
         super.destroy()
         blockEntities.remove(this)
+        if (level is ServerLevel) LinkCountManager.sync(level as ServerLevel)
     }
 
     override fun remove() {
         super.remove()
         blockEntities.remove(this)
+        if (level is ServerLevel) LinkCountManager.sync(level as ServerLevel)
     }
 
     override fun onChunkUnloaded() {
         super.onChunkUnloaded()
         blockEntities.remove(this)
+        if (level is ServerLevel) LinkCountManager.sync(level as ServerLevel)
     }
 }

--- a/src/main/kotlin/io/github/cotrin8672/cel/event/ServerEvents.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/event/ServerEvents.kt
@@ -2,6 +2,7 @@ package io.github.cotrin8672.cel.event
 
 import io.github.cotrin8672.cel.network.SyncSharedStoragePacket
 import io.github.cotrin8672.cel.util.SharedStorageHandler
+import io.github.cotrin8672.cel.util.LinkCountManager
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.server.level.ServerPlayer
 import net.neoforged.bus.api.SubscribeEvent
@@ -18,5 +19,6 @@ object ServerEvents {
         val level = player.serverLevel()
         val nbt = SharedStorageHandler.instance?.save(CompoundTag(), level.registryAccess()) ?: return
         PacketDistributor.sendToPlayer(player, SyncSharedStoragePacket(nbt))
+        LinkCountManager.sync(player)
     }
 }

--- a/src/main/kotlin/io/github/cotrin8672/cel/network/SyncFrequencyCountPacket.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/network/SyncFrequencyCountPacket.kt
@@ -1,0 +1,21 @@
+package io.github.cotrin8672.cel.network
+
+import io.github.cotrin8672.cel.CreateEnderLink
+import io.netty.buffer.ByteBuf
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.network.codec.ByteBufCodecs
+import net.minecraft.network.codec.StreamCodec
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload
+
+data class SyncFrequencyCountPacket(val data: CompoundTag) : CustomPacketPayload {
+    companion object {
+        val TYPE = CustomPacketPayload.Type<SyncFrequencyCountPacket>(CreateEnderLink.asResource("sync_frequency_count"))
+        val STREAM_CODEC: StreamCodec<ByteBuf, SyncFrequencyCountPacket> = StreamCodec.composite(
+            ByteBufCodecs.COMPOUND_TAG,
+            SyncFrequencyCountPacket::data,
+            ::SyncFrequencyCountPacket
+        )
+    }
+
+    override fun type(): CustomPacketPayload.Type<out CustomPacketPayload> = TYPE
+}

--- a/src/main/kotlin/io/github/cotrin8672/cel/util/LinkCountManager.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/util/LinkCountManager.kt
@@ -1,0 +1,49 @@
+package io.github.cotrin8672.cel.util
+
+import net.minecraft.world.level.block.entity.BlockEntity
+import io.github.cotrin8672.cel.util.StorageFrequency
+
+import io.github.cotrin8672.cel.content.SharedStorageBehaviour
+import io.github.cotrin8672.cel.content.block.tank.EnderTankBlockEntity
+import io.github.cotrin8672.cel.content.block.vault.EnderVaultBlockEntity
+import io.github.cotrin8672.cel.network.SyncFrequencyCountPacket
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.nbt.ListTag
+import net.minecraft.server.level.ServerPlayer
+import com.simibubi.create.foundation.blockEntity.SmartBlockEntity
+import net.minecraft.server.level.ServerLevel
+import net.neoforged.neoforge.network.PacketDistributor
+
+object LinkCountManager {
+    fun sync(level: ServerLevel) {
+        val tag = CompoundTag()
+        tag.put("vault", createList(EnderVaultBlockEntity.getLoadingBlockEntities(), level))
+        tag.put("tank", createList(EnderTankBlockEntity.getLoadingBlockEntities(), level))
+        PacketDistributor.sendToAllPlayers(SyncFrequencyCountPacket(tag))
+    }
+
+    fun sync(player: net.minecraft.server.level.ServerPlayer) {
+        val level = player.serverLevel()
+        val tag = CompoundTag()
+        tag.put("vault", createList(EnderVaultBlockEntity.getLoadingBlockEntities(), level))
+        tag.put("tank", createList(EnderTankBlockEntity.getLoadingBlockEntities(), level))
+        PacketDistributor.sendToPlayer(player, SyncFrequencyCountPacket(tag))
+    }
+
+    private fun createList(blockEntities: Set<out BlockEntity>, level: ServerLevel): ListTag {
+        val counts = mutableMapOf<StorageFrequency, Int>()
+        for (be in blockEntities) {
+            val behaviour = (be as? SmartBlockEntity)?.getBehaviour(SharedStorageBehaviour.TYPE) ?: continue
+            val freq = behaviour.getFrequency()
+            counts[freq] = (counts[freq] ?: 0) + 1
+        }
+        val list = ListTag()
+        for ((freq, count) in counts) {
+            val ct = CompoundTag()
+            ct.put("StorageFrequency", freq.saveOptional(level.registryAccess()))
+            ct.putInt("Count", count)
+            list.add(ct)
+        }
+        return list
+    }
+}


### PR DESCRIPTION
## Summary
- sync link counts from server
- add packet and client storage for frequency counts
- update block entities and behaviours to notify server on changes
- send counts to players when they join

## Testing
- `./gradlew --version`
- `./gradlew build` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_684331876cbc832b961f8212e0283c06