### PR TITLE
Fix link count desync by server tracking

### DIFF
--- a/src/main/kotlin/io/github/cotrin8672/cel/CreateEnderLink.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/CreateEnderLink.kt
@@ -8,6 +8,8 @@ import io.github.cotrin8672.cel.content.block.tank.EnderTankBlockEntity
 import io.github.cotrin8672.cel.content.block.vault.EnderVaultBlockEntity
 import io.github.cotrin8672.cel.datagen.CelDatagen
 import io.github.cotrin8672.cel.network.SyncSharedStoragePacket
+import io.github.cotrin8672.cel.network.SyncLinkCountPacket
+import io.github.cotrin8672.cel.client.LinkCountCache
 import io.github.cotrin8672.cel.registry.*
 import io.github.cotrin8672.cel.util.SharedStorageHandler
 import net.createmod.catnip.lang.FontHelper
@@ -63,6 +65,17 @@ object CreateEnderLink {
             context.enqueueWork {
                 val level = context.player().level()
                 SharedStorageHandler.instance = SharedStorageHandler.load(packet.data, level.registryAccess())
+            }
+        }
+
+        registrar.playBidirectional(
+            SyncLinkCountPacket.TYPE,
+            SyncLinkCountPacket.STREAM_CODEC,
+        ) { packet, context ->
+            context.enqueueWork {
+                val player = context.player()
+                val provider = player.level().registryAccess()
+                LinkCountCache.handlePacket(packet.data, provider)
             }
         }
     }

--- a/src/main/kotlin/io/github/cotrin8672/cel/client/LinkCountCache.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/client/LinkCountCache.kt
@@ -1,0 +1,35 @@
+package io.github.cotrin8672.cel.client
+
+import io.github.cotrin8672.cel.util.StorageFrequency
+import net.minecraft.core.HolderLookup
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.nbt.ListTag
+import net.minecraft.nbt.Tag
+
+/**
+ * Client side cache for storing the latest link counts per frequency
+ * sent from the server.
+ */
+object LinkCountCache {
+    private val vaultCounts: MutableMap<StorageFrequency, Int> = mutableMapOf()
+    private val tankCounts: MutableMap<StorageFrequency, Int> = mutableMapOf()
+
+    fun handlePacket(tag: CompoundTag, provider: HolderLookup.Provider) {
+        vaultCounts.clear()
+        tankCounts.clear()
+        readList(tag.getList("vaults", Tag.TAG_COMPOUND.toInt()), provider, vaultCounts)
+        readList(tag.getList("tanks", Tag.TAG_COMPOUND.toInt()), provider, tankCounts)
+    }
+
+    fun getVaultCount(freq: StorageFrequency): Int = vaultCounts[freq] ?: 0
+    fun getTankCount(freq: StorageFrequency): Int = tankCounts[freq] ?: 0
+
+    private fun readList(list: ListTag, provider: HolderLookup.Provider, map: MutableMap<StorageFrequency, Int>) {
+        for (element in list) {
+            if (element !is CompoundTag) continue
+            val freq = StorageFrequency.parseOptional(provider, element.getCompound("StorageFrequency"))
+            val count = element.getInt("Count")
+            map[freq] = count
+        }
+    }
+}

--- a/src/main/kotlin/io/github/cotrin8672/cel/content/SharedStorageBehaviour.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/content/SharedStorageBehaviour.kt
@@ -12,6 +12,7 @@ import com.simibubi.create.infrastructure.config.AllConfigs
 import io.github.cotrin8672.cel.registry.CelDataComponents
 import io.github.cotrin8672.cel.registry.CelItems
 import io.github.cotrin8672.cel.util.CelLang
+import io.github.cotrin8672.cel.client.LinkCountCache
 import io.github.cotrin8672.cel.util.StorageFrequency
 import io.github.cotrin8672.cel.util.use
 import net.createmod.catnip.math.VecHelper
@@ -235,12 +236,20 @@ open class SharedStorageBehaviour(
         tooltip: MutableList<Component>,
         isPlayerSneaking: Boolean,
         blockEntities: Set<SmartBlockEntity>,
+        isVault: Boolean,
     ) {
         val frequencyItem = getFrequency().stack
         val frequencyOwner = getFrequency().resolvableProfile
 
-        val count = blockEntities.count {
-            getFrequency() == it.getBehaviour(SharedStorageBehaviour.TYPE).getFrequency()
+        val count = if (blockEntity.level?.isClientSide == true) {
+            if (isVault)
+                LinkCountCache.getVaultCount(getFrequency())
+            else
+                LinkCountCache.getTankCount(getFrequency())
+        } else {
+            blockEntities.count {
+                getFrequency() == it.getBehaviour(SharedStorageBehaviour.TYPE).getFrequency()
+            }
         }
 
         CelLang.translate("gui.goggles.storage_stat").forGoggles(tooltip)

--- a/src/main/kotlin/io/github/cotrin8672/cel/content/block/tank/EnderTankBlockEntity.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/content/block/tank/EnderTankBlockEntity.kt
@@ -8,6 +8,7 @@ import io.github.cotrin8672.cel.content.SharedStorageBehaviour
 import io.github.cotrin8672.cel.content.storage.SharedFluidTank
 import io.github.cotrin8672.cel.registry.CelBlockEntityTypes
 import io.github.cotrin8672.cel.util.SharedStorageHandler
+import io.github.cotrin8672.cel.util.LinkCountTracker
 import net.createmod.ponder.api.level.PonderLevel
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
@@ -17,6 +18,7 @@ import net.minecraft.network.chat.CommonComponents
 import net.minecraft.network.chat.Component
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.server.level.ServerLevel
 import net.neoforged.neoforge.capabilities.Capabilities
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent
 import java.util.*
@@ -43,7 +45,17 @@ class EnderTankBlockEntity(
 
     init {
         val isAlreadyExists = blockEntities.map { it.blockPos }.contains(this.blockPos)
-        if (!isAlreadyExists) blockEntities.add(this)
+        if (!isAlreadyExists) {
+            blockEntities.add(this)
+            LinkCountTracker.track(this)
+        }
+    }
+
+    override fun onLoad() {
+        super.onLoad()
+        if (level is ServerLevel) {
+            LinkCountTracker.track(this)
+        }
     }
 
     private var luminosity = 0
@@ -92,7 +104,7 @@ class EnderTankBlockEntity(
         )
         tooltip.add(CommonComponents.EMPTY)
 
-        getBehaviour(SharedStorageBehaviour.TYPE).addToGoggleTooltip(tooltip, isPlayerSneaking, blockEntities)
+        getBehaviour(SharedStorageBehaviour.TYPE).addToGoggleTooltip(tooltip, isPlayerSneaking, blockEntities, false)
 
         return true
     }
@@ -100,16 +112,19 @@ class EnderTankBlockEntity(
     override fun destroy() {
         super.destroy()
         blockEntities.remove(this)
+        LinkCountTracker.untrack(this)
     }
 
     override fun remove() {
         super.remove()
         blockEntities.remove(this)
+        LinkCountTracker.untrack(this)
     }
 
     override fun onChunkUnloaded() {
         super.onChunkUnloaded()
         blockEntities.remove(this)
+        LinkCountTracker.untrack(this)
     }
 
     override fun sendData() {

--- a/src/main/kotlin/io/github/cotrin8672/cel/content/block/vault/EnderVaultBlockEntity.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/content/block/vault/EnderVaultBlockEntity.kt
@@ -7,6 +7,7 @@ import com.simibubi.create.foundation.blockEntity.behaviour.CenteredSideValueBox
 import io.github.cotrin8672.cel.content.SharedStorageBehaviour
 import io.github.cotrin8672.cel.registry.CelBlockEntityTypes
 import io.github.cotrin8672.cel.util.SharedStorageHandler
+import io.github.cotrin8672.cel.util.LinkCountTracker
 import net.minecraft.core.BlockPos
 import net.minecraft.network.chat.Component
 import net.minecraft.server.level.ServerLevel
@@ -38,7 +39,17 @@ class EnderVaultBlockEntity(
 
     init {
         val isAlreadyExists = blockEntities.map { it.blockPos }.contains(this.blockPos)
-        if (!isAlreadyExists) blockEntities.add(this)
+        if (!isAlreadyExists) {
+            blockEntities.add(this)
+            LinkCountTracker.track(this)
+        }
+    }
+
+    override fun onLoad() {
+        super.onLoad()
+        if (level is ServerLevel) {
+            LinkCountTracker.track(this)
+        }
     }
 
     private fun getInventory(): IItemHandler? {
@@ -59,7 +70,7 @@ class EnderVaultBlockEntity(
 
     override fun addToGoggleTooltip(tooltip: MutableList<Component>, isPlayerSneaking: Boolean): Boolean {
         super.addToGoggleTooltip(tooltip, isPlayerSneaking)
-        getBehaviour(SharedStorageBehaviour.TYPE).addToGoggleTooltip(tooltip, isPlayerSneaking, blockEntities)
+        getBehaviour(SharedStorageBehaviour.TYPE).addToGoggleTooltip(tooltip, isPlayerSneaking, blockEntities, true)
 
         return true
     }
@@ -67,15 +78,18 @@ class EnderVaultBlockEntity(
     override fun destroy() {
         super.destroy()
         blockEntities.remove(this)
+        LinkCountTracker.untrack(this)
     }
 
     override fun remove() {
         super.remove()
         blockEntities.remove(this)
+        LinkCountTracker.untrack(this)
     }
 
     override fun onChunkUnloaded() {
         super.onChunkUnloaded()
         blockEntities.remove(this)
+        LinkCountTracker.untrack(this)
     }
 }

--- a/src/main/kotlin/io/github/cotrin8672/cel/event/CommonEvents.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/event/CommonEvents.kt
@@ -1,6 +1,8 @@
 package io.github.cotrin8672.cel.event
 
 import io.github.cotrin8672.cel.util.SharedStorageHandler
+import io.github.cotrin8672.cel.util.LinkCountTracker
+import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.level.saveddata.SavedData.Factory
 import net.neoforged.bus.api.SubscribeEvent
 import net.neoforged.fml.common.EventBusSubscriber
@@ -28,5 +30,8 @@ object CommonEvents {
     @SubscribeEvent
     fun onTickEvent(event: LevelTickEvent.Pre) {
         SharedStorageHandler.instance?.tick()
+        val level = event.level
+        if (level is ServerLevel)
+            LinkCountTracker.tick(level)
     }
 }

--- a/src/main/kotlin/io/github/cotrin8672/cel/event/ServerEvents.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/event/ServerEvents.kt
@@ -2,6 +2,7 @@ package io.github.cotrin8672.cel.event
 
 import io.github.cotrin8672.cel.network.SyncSharedStoragePacket
 import io.github.cotrin8672.cel.util.SharedStorageHandler
+import io.github.cotrin8672.cel.util.LinkCountTracker
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.server.level.ServerPlayer
 import net.neoforged.bus.api.SubscribeEvent
@@ -18,5 +19,6 @@ object ServerEvents {
         val level = player.serverLevel()
         val nbt = SharedStorageHandler.instance?.save(CompoundTag(), level.registryAccess()) ?: return
         PacketDistributor.sendToPlayer(player, SyncSharedStoragePacket(nbt))
+        LinkCountTracker.sendToPlayer(player)
     }
 }

--- a/src/main/kotlin/io/github/cotrin8672/cel/network/SyncLinkCountPacket.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/network/SyncLinkCountPacket.kt
@@ -1,0 +1,28 @@
+package io.github.cotrin8672.cel.network
+
+import io.github.cotrin8672.cel.CreateEnderLink
+import io.netty.buffer.ByteBuf
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.network.codec.ByteBufCodecs
+import net.minecraft.network.codec.StreamCodec
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload
+
+/**
+ * Packet used to synchronize the amount of loaded block entities per frequency
+ * from the server to the client.
+ */
+data class SyncLinkCountPacket(val data: CompoundTag) : CustomPacketPayload {
+    companion object {
+        val TYPE = CustomPacketPayload.Type<SyncLinkCountPacket>(CreateEnderLink.asResource("sync_link_counts"))
+
+        val STREAM_CODEC: StreamCodec<ByteBuf, SyncLinkCountPacket> = StreamCodec.composite(
+            ByteBufCodecs.COMPOUND_TAG,
+            SyncLinkCountPacket::data,
+            ::SyncLinkCountPacket
+        )
+    }
+
+    override fun type(): CustomPacketPayload.Type<out CustomPacketPayload> {
+        return TYPE
+    }
+}

--- a/src/main/kotlin/io/github/cotrin8672/cel/util/LinkCountTracker.kt
+++ b/src/main/kotlin/io/github/cotrin8672/cel/util/LinkCountTracker.kt
@@ -1,0 +1,105 @@
+package io.github.cotrin8672.cel.util
+
+import com.simibubi.create.foundation.blockEntity.SmartBlockEntity
+import io.github.cotrin8672.cel.content.SharedStorageBehaviour
+import io.github.cotrin8672.cel.content.block.tank.EnderTankBlockEntity
+import io.github.cotrin8672.cel.content.block.vault.EnderVaultBlockEntity
+import io.github.cotrin8672.cel.network.SyncLinkCountPacket
+import net.minecraft.core.HolderLookup
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.nbt.ListTag
+import net.minecraft.nbt.Tag
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.server.level.ServerPlayer
+import net.neoforged.neoforge.network.PacketDistributor
+import java.util.Collections
+import java.util.WeakHashMap
+
+/**
+ * Tracks loaded Ender Vaults and Ender Tanks on the server and synchronises the
+ * amount of loaded block entities per frequency to connected clients.
+ */
+object LinkCountTracker {
+    private val vaults: MutableSet<EnderVaultBlockEntity> = Collections.newSetFromMap(WeakHashMap())
+    private val tanks: MutableSet<EnderTankBlockEntity> = Collections.newSetFromMap(WeakHashMap())
+
+    private var dirty = false
+    private var lastVault: Map<StorageFrequency, Int> = emptyMap()
+    private var lastTank: Map<StorageFrequency, Int> = emptyMap()
+
+    fun track(be: EnderVaultBlockEntity) {
+        if (be.level !is ServerLevel) return
+        vaults.add(be)
+        dirty = true
+    }
+
+    fun untrack(be: EnderVaultBlockEntity) {
+        if (be.level !is ServerLevel) return
+        vaults.remove(be)
+        dirty = true
+    }
+
+    fun track(be: EnderTankBlockEntity) {
+        if (be.level !is ServerLevel) return
+        tanks.add(be)
+        dirty = true
+    }
+
+    fun untrack(be: EnderTankBlockEntity) {
+        if (be.level !is ServerLevel) return
+        tanks.remove(be)
+        dirty = true
+    }
+
+    fun tick(level: ServerLevel) {
+        if (!dirty) return
+        dirty = false
+
+        val vaultCounts = computeCounts(vaults)
+        val tankCounts = computeCounts(tanks)
+        if (vaultCounts != lastVault || tankCounts != lastTank) {
+            lastVault = vaultCounts
+            lastTank = tankCounts
+            val tag = buildTag(level.registryAccess(), vaultCounts, tankCounts)
+            PacketDistributor.sendToAllPlayers(SyncLinkCountPacket(tag))
+        }
+    }
+
+    fun sendToPlayer(player: ServerPlayer) {
+        val level = player.serverLevel()
+        val tag = buildTag(level.registryAccess(), computeCounts(vaults), computeCounts(tanks))
+        PacketDistributor.sendToPlayer(player, SyncLinkCountPacket(tag))
+    }
+
+    private fun computeCounts(set: Set<out SmartBlockEntity>): Map<StorageFrequency, Int> {
+        val map = mutableMapOf<StorageFrequency, Int>()
+        for (be in set) {
+            val behaviour = be.getBehaviour(SharedStorageBehaviour.TYPE) ?: continue
+            val freq = behaviour.getFrequency()
+            map[freq] = (map[freq] ?: 0) + 1
+        }
+        return map
+    }
+
+    private fun buildTag(
+        provider: HolderLookup.Provider,
+        vault: Map<StorageFrequency, Int>,
+        tank: Map<StorageFrequency, Int>
+    ): CompoundTag {
+        val tag = CompoundTag()
+        tag.put("vaults", countsToList(vault, provider))
+        tag.put("tanks", countsToList(tank, provider))
+        return tag
+    }
+
+    private fun countsToList(counts: Map<StorageFrequency, Int>, provider: HolderLookup.Provider): ListTag {
+        val list = ListTag()
+        for ((freq, count) in counts) {
+            val t = CompoundTag()
+            t.put("StorageFrequency", freq.saveOptional(provider))
+            t.putInt("Count", count)
+            list.add(t)
+        }
+        return list
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LinkCountTracker` for server-side management of block entity instances
- add `SyncLinkCountPacket` network packet
- cache counts on the client via `LinkCountCache`
- update block entities and behaviours to use the new system
- send counts on player login and whenever instances change

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6843d78c90c4832b8ab91a346f4d94a4